### PR TITLE
allow cross-origin for Random

### DIFF
--- a/src/main/webapp/WEB-INF/groovy/random.groovy
+++ b/src/main/webapp/WEB-INF/groovy/random.groovy
@@ -47,6 +47,10 @@ if (image) {
         log.log(Level.WARNING, "Exception updating impressions on image", e)
     }
 
+    response.setHeader("Access-Control-Allow-Origin", "*")
+    response.setHeader("Access-Control-Allow-Methods", "GET")
+    response.setHeader("Access-Control-Allow-Credentials", "true")
+    response.setHeader 'Strict-Transport-Security', 'max-age=300; preload'
     response.sendRedirect(AppUtil.instance.patchUrl(image.dataUrl, request))
 
 } else {


### PR DESCRIPTION
I hope to acess to  'http://www.lgtm.in/g' from my bookmarklet. It requires 'Access-Control-Allow-Origin' header in redirect response.

I tested this bookmarklet on local machine.
```
javascript:(function(){
  var xhr = new XMLHttpRequest();
  xhr.open('GET', 'http://localhost:8080/g', true);
  xhr.onreadystatechange=function(){
    if (xhr.readyState==4) {
      alert(xhr.responseText);
    }
  };
  xhr.send(null);
})();
```